### PR TITLE
Check zero bytes in truncating evm address

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -47,7 +47,7 @@ var ErrUnsupportedEcosystem = fmt.Errorf("ecosystem is unsupported")
 func NewAddress(b []byte, e chainid.Ecosystem) (Address, error) {
 	switch e {
 	case chainid.EcosystemEVM:
-		return NewEvmAddressTruncating(b)
+		return NewEvmAddress(b)
 	case chainid.EcosystemSui:
 		return NewSuiAddress(b)
 	case chainid.EcosystemSolana:

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -113,16 +113,16 @@ func TestEVMAddress(t *testing.T) {
 
 		// Error from longer non-zero bytes
 		longerAddrBytes := append(validAddress.Bytes(), validAddress.Bytes()...)
-		_, err = address.NewEvmAddressTruncating(longerAddrBytes)
+		_, err = address.NewEvmAddress(longerAddrBytes)
 		common.AssertError(t, err, address.ErrBadAddress, address.ErrBadAddressEvm)
 
 		// Error on shorter bytes
-		_, err = address.NewEvmAddressTruncating(longerAddrBytes[:10])
+		_, err = address.NewEvmAddress(longerAddrBytes[:10])
 		common.AssertError(t, err, address.ErrBadAddress, address.ErrBadAddressEvm)
 
 		// Should create from longer bytes with leading zeroes
 		longerAddrBytesWithZeroes := append(make([]byte, 12), validAddress.Bytes()...)
-		addrFromLongerWithZeroes, err := address.NewEvmAddressTruncating(longerAddrBytesWithZeroes)
+		addrFromLongerWithZeroes, err := address.NewEvmAddress(longerAddrBytesWithZeroes)
 		common.AssertNoError(t, err)
 		common.AssertTrue(t, addrFromLongerWithZeroes.Equal(validAddress))
 	})

--- a/address/evm.go
+++ b/address/evm.go
@@ -43,9 +43,14 @@ func NewEvmAddressFromHex(address string) (*EvmAddress, error) {
 // NewEvmAddressTruncating creates a new EvmAddress from a byte slice which is longer than
 // EvmAddressLength by truncating most significant bytes. This is useful when creating an
 // address from a event topic which is always 32 bytes long.
+// It returns an error if the byte slice is shorter than EvmAddressLength or truncated bytes
+// are not zeroes.
 func NewEvmAddressTruncating(b []byte) (*EvmAddress, error) {
 	if len(b) < EvmAddressLength {
 		return nil, fmt.Errorf("%w: invalid length, given %d, expected at least %d", ErrBadAddressEvm, len(b), EvmAddressLength)
+	}
+	if !bytes.Equal(b[:len(b)-EvmAddressLength], make([]byte, len(b)-EvmAddressLength)) {
+		return nil, fmt.Errorf("%w: truncated bytes are not zeroes", ErrBadAddressEvm)
 	}
 
 	a := &EvmAddress{}

--- a/address/evm.go
+++ b/address/evm.go
@@ -19,14 +19,18 @@ type EvmAddress struct {
 	inner [EvmAddressLength]byte
 }
 
-// NewEvmAddress creates a new EvmAddress from a 20-bytes array
-func NewEvmAddress(address []byte) (*EvmAddress, error) {
-	if len(address) != EvmAddressLength {
-		return nil, fmt.Errorf("%w: invalid length, given %d, expected %d", ErrBadAddressEvm, len(address), EvmAddressLength)
+// NewEvmAddress creates a new EvmAddress from a byte slice. If slice is longer than 20 bytes, most significant ones
+// are truncated. An error is returned if the slice is shorter than 20 bytes or if the truncated bytes are not zeroes.
+func NewEvmAddress(b []byte) (*EvmAddress, error) {
+	if len(b) < EvmAddressLength {
+		return nil, fmt.Errorf("%w: invalid length, given %d, expected at least %d", ErrBadAddressEvm, len(b), EvmAddressLength)
+	}
+	if !bytes.Equal(b[:len(b)-EvmAddressLength], make([]byte, len(b)-EvmAddressLength)) {
+		return nil, fmt.Errorf("%w: truncated bytes are not zeroes", ErrBadAddressEvm)
 	}
 
 	a := &EvmAddress{}
-	copy(a.inner[:], address)
+	copy(a.inner[:], b[len(b)-EvmAddressLength:])
 	return a, nil
 }
 
@@ -38,24 +42,6 @@ func NewEvmAddressFromHex(address string) (*EvmAddress, error) {
 		return nil, fmt.Errorf("%w: hex decode error %w", ErrBadAddressEvm, err)
 	}
 	return NewEvmAddress(decoded)
-}
-
-// NewEvmAddressTruncating creates a new EvmAddress from a byte slice which is longer than
-// EvmAddressLength by truncating most significant bytes. This is useful when creating an
-// address from a event topic which is always 32 bytes long.
-// It returns an error if the byte slice is shorter than EvmAddressLength or truncated bytes
-// are not zeroes.
-func NewEvmAddressTruncating(b []byte) (*EvmAddress, error) {
-	if len(b) < EvmAddressLength {
-		return nil, fmt.Errorf("%w: invalid length, given %d, expected at least %d", ErrBadAddressEvm, len(b), EvmAddressLength)
-	}
-	if !bytes.Equal(b[:len(b)-EvmAddressLength], make([]byte, len(b)-EvmAddressLength)) {
-		return nil, fmt.Errorf("%w: truncated bytes are not zeroes", ErrBadAddressEvm)
-	}
-
-	a := &EvmAddress{}
-	copy(a.inner[:], b[len(b)-EvmAddressLength:])
-	return a, nil
 }
 
 func (a *EvmAddress) String() string {


### PR DESCRIPTION
Return an error if, when truncating bytes for an evm address, such bytes are not zero.